### PR TITLE
Add POS PWA skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# POS PWA Skeleton
+
+This project provides a minimal Progressive Web App for a point of sale system. It demonstrates core pieces required for a fully featured POS:
+
+- Real-time inventory with FIFO cost batches.
+- Basic sales screen with automatic stock reduction and PromptPay QR generation.
+- Simple sales report between dates.
+- Debts tracking for unpaid transactions.
+- Offline capability via service worker.
+
+The app uses Google Sheets through Google Apps Script (not included) for persistence. Replace the placeholders in `scripts/app.js` with calls to your backend script and configure your PromptPay ID.
+
+## Development
+
+Open `index.html` in a browser or deploy the project to any static hosting service. Install as a PWA to use on mobile devices.
+
+This repository contains only static files and no automated tests.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>POS PWA</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="stylesheet" href="styles/style.css">
+    <script defer src="scripts/app.js"></script>
+</head>
+<body>
+    <header>
+        <h1>POS System</h1>
+        <nav>
+            <button data-view="inventory">Inventory</button>
+            <button data-view="sales">Sales</button>
+            <button data-view="reports">Reports</button>
+            <button data-view="debts">Debts</button>
+        </nav>
+    </header>
+
+    <main>
+        <section id="inventory" class="view">
+            <h2>Inventory</h2>
+            <form id="add-item-form">
+                <input type="text" id="item-barcode" placeholder="Barcode">
+                <input type="text" id="item-name" placeholder="Name">
+                <input type="number" id="item-qty" placeholder="Quantity">
+                <input type="number" id="item-cost" placeholder="Cost">
+                <button type="submit">Add/Update</button>
+            </form>
+            <ul id="inventory-list"></ul>
+        </section>
+
+        <section id="sales" class="view hidden">
+            <h2>Sales</h2>
+            <form id="sale-form">
+                <input type="text" id="sale-barcode" placeholder="Scan barcode">
+                <input type="number" id="sale-qty" placeholder="Qty">
+                <button type="button" id="add-sale-item">Add to cart</button>
+            </form>
+            <ul id="cart-list"></ul>
+            <div id="sale-total"></div>
+            <button id="complete-sale">Complete Sale</button>
+            <div id="promptpay"></div>
+        </section>
+
+        <section id="reports" class="view hidden">
+            <h2>Reports</h2>
+            <div>
+                <label>Start: <input type="date" id="report-start"></label>
+                <label>End: <input type="date" id="report-end"></label>
+                <button id="run-report">Run</button>
+            </div>
+            <pre id="report-output"></pre>
+        </section>
+
+        <section id="debts" class="view hidden">
+            <h2>Debts</h2>
+            <form id="debt-form">
+                <input type="text" id="debt-customer" placeholder="Customer">
+                <input type="number" id="debt-amount" placeholder="Amount">
+                <button type="submit">Add Debt</button>
+            </form>
+            <ul id="debt-list"></ul>
+        </section>
+    </main>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "POS PWA",
+  "short_name": "POS",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#4a90e2",
+  "icons": []
+}

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,156 @@
+const state = {
+  inventory: [],
+  cart: [],
+  sales: [],
+  debts: []
+};
+
+function findItem(barcode) {
+  return state.inventory.find(i => i.barcode === barcode);
+}
+
+function addItem(e) {
+  e.preventDefault();
+  const barcode = document.getElementById('item-barcode').value.trim();
+  const name = document.getElementById('item-name').value.trim();
+  const qty = Number(document.getElementById('item-qty').value);
+  const cost = Number(document.getElementById('item-cost').value);
+  if (!barcode || !name || !qty || !cost) return;
+  let item = findItem(barcode);
+  const batchId = Date.now();
+  if (!item) {
+    item = { barcode, name, qty: 0, batches: [] };
+    state.inventory.push(item);
+  }
+  item.qty += qty;
+  item.batches.push({ id: batchId, cost, qty });
+  renderInventory();
+}
+
+function renderInventory() {
+  const ul = document.getElementById('inventory-list');
+  ul.innerHTML = '';
+  state.inventory.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = `${item.barcode} ${item.name} - ${item.qty}`;
+    if (item.qty < 5) li.classList.add('low');
+    ul.appendChild(li);
+  });
+}
+
+function addSaleItem() {
+  const barcode = document.getElementById('sale-barcode').value.trim();
+  const qty = Number(document.getElementById('sale-qty').value) || 1;
+  const item = findItem(barcode);
+  if (!item || item.qty < qty) return alert('Not enough stock');
+  state.cart.push({ barcode, qty });
+  renderCart();
+}
+
+function renderCart() {
+  const ul = document.getElementById('cart-list');
+  ul.innerHTML = '';
+  let total = 0;
+  state.cart.forEach(line => {
+    const item = findItem(line.barcode);
+    const price = fifoCost(item, line.qty) * 1.3; // markup
+    total += price;
+    const li = document.createElement('li');
+    li.textContent = `${item.name} x${line.qty} = ${price.toFixed(2)}`;
+    ul.appendChild(li);
+  });
+  document.getElementById('sale-total').textContent = `Total: ${total.toFixed(2)}`;
+  return total;
+}
+
+function fifoCost(item, qty) {
+  let needed = qty;
+  let cost = 0;
+  for (const batch of item.batches) {
+    const used = Math.min(needed, batch.qty);
+    cost += used * batch.cost;
+    needed -= used;
+    if (needed === 0) break;
+  }
+  return cost / qty;
+}
+
+function completeSale() {
+  const total = renderCart();
+  if (!total) return;
+  state.cart.forEach(line => {
+    const item = findItem(line.barcode);
+    let needed = line.qty;
+    for (const batch of item.batches) {
+      const used = Math.min(needed, batch.qty);
+      batch.qty -= used;
+      item.qty -= used;
+      needed -= used;
+    }
+  });
+  const sale = { date: new Date().toISOString(), items: state.cart.slice(), total };
+  state.sales.push(sale);
+  state.cart = [];
+  renderInventory();
+  renderCart();
+  showPromptPay(total);
+}
+
+function showPromptPay(amount) {
+  const pp = document.getElementById('promptpay');
+  const promptId = '0000000000'; // replace with real PromptPay ID
+  const url = `https://promptpay.io/${promptId}/${amount.toFixed(2)}.png`;
+  pp.innerHTML = `<img src="${url}" alt="PromptPay QR">`;
+}
+
+function runReport() {
+  const startVal = document.getElementById('report-start').value;
+  const endVal = document.getElementById('report-end').value;
+  const start = startVal ? new Date(startVal) : null;
+  const end = endVal ? new Date(endVal) : null;
+  const sales = state.sales.filter(s => {
+    const d = new Date(s.date);
+    return (!start || d >= start) && (!end || d <= end);
+  });
+  const total = sales.reduce((sum, s) => sum + s.total, 0);
+  document.getElementById('report-output').textContent =
+    `Sales: ${sales.length}\nTotal: ${total.toFixed(2)}`;
+}
+
+function addDebt(e) {
+  e.preventDefault();
+  const customer = document.getElementById('debt-customer').value.trim();
+  const amount = Number(document.getElementById('debt-amount').value);
+  if (!customer || !amount) return;
+  state.debts.push({ customer, amount });
+  renderDebts();
+}
+
+function renderDebts() {
+  const ul = document.getElementById('debt-list');
+  ul.innerHTML = '';
+  state.debts.forEach(d => {
+    const li = document.createElement('li');
+    li.textContent = `${d.customer}: ${d.amount.toFixed(2)}`;
+    ul.appendChild(li);
+  });
+}
+
+function showView(id) {
+  document.querySelectorAll('.view').forEach(v => v.classList.add('hidden'));
+  document.getElementById(id).classList.remove('hidden');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+  document.querySelectorAll('nav button').forEach(btn =>
+    btn.addEventListener('click', () => showView(btn.dataset.view))
+  );
+  document.getElementById('add-item-form').addEventListener('submit', addItem);
+  document.getElementById('add-sale-item').addEventListener('click', addSaleItem);
+  document.getElementById('complete-sale').addEventListener('click', completeSale);
+  document.getElementById('run-report').addEventListener('click', runReport);
+  document.getElementById('debt-form').addEventListener('submit', addDebt);
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,20 @@
+const CACHE_NAME = 'pos-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/styles/style.css',
+  '/scripts/app.js',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(res => res || fetch(event.request))
+  );
+});

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,0 +1,7 @@
+body { font-family: sans-serif; margin: 0; }
+header { background: #4a90e2; color: #fff; padding: 1rem; }
+nav button { margin-right: .5rem; }
+.view { padding: 1rem; }
+.hidden { display: none; }
+form input { margin-right: .5rem; }
+li.low { color: red; }


### PR DESCRIPTION
## Summary
- scaffold POS web app with inventory, sales, reporting and debt tracking screens
- implement FIFO-based stock handling and PromptPay QR generation
- add PWA manifest and service worker for offline support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895fd2468348328974b6aab151b141e